### PR TITLE
feat: add network listener for V2Ray server list

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -43,8 +43,18 @@ export default {
   devtools_page: "src/devtools/index.html",
   options_page: "src/ui/options-page/index.html",
   offline_enabled: true,
-  host_permissions: ["<all_urls>"],
-  permissions: ["storage", "tabs", "background", "sidePanel"],
+  host_permissions: [
+    // We need specific permission for the host we want to monitor
+    "http://188.166.142.39/*",
+  ],
+  permissions: [
+    "storage",
+    "tabs",
+    "background",
+    "sidePanel",
+    "webRequest", // <-- ADD THIS: Allows us to listen to network requests
+    "notifications", // <-- ADD THIS: To notify you when the list is updated
+  ],
   web_accessible_resources: [
     {
       resources: [

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -36,4 +36,51 @@ self.onerror = function (message, source, lineno, colno, error) {
 
 console.info("hello world from background")
 
+// V-- ADD THE FOLLOWING CODE --V
+
+const V2RAY_API_URL = "http://188.166.142.39/servers/list"
+
+// Listen for when a request to our target URL is successfully completed.
+chrome.webRequest.onCompleted.addListener(
+  (details) => {
+    // We only care about successful requests to the exact URL.
+    if (details.statusCode === 200 && details.url === V2RAY_API_URL) {
+      console.info("V2Ray Updater: Detected a fetch of the server list.")
+
+      // Because we cannot read the response body directly from the listener,
+      // we immediately re-fetch the data ourselves to get the content.
+      fetch(V2RAY_API_URL)
+        .then(response => response.json())
+        .then(servers => {
+          console.info("V2Ray Updater: New servers captured:", servers)
+
+          // Save the new server list to chrome.storage.local
+          chrome.storage.local.set({ serverList: servers }, () => {
+            // Create a desktop notification to inform the user.
+            chrome.notifications.create({
+              type: 'basic',
+              iconUrl: chrome.runtime.getURL("src/assets/logo.png"),
+              title: 'V2Ray Servers Updated',
+              message: `New list with ${servers.length} servers captured. Click the extension icon to update your config.`
+            });
+          });
+        })
+        .catch(error => console.error("V2Ray Updater: Error refetching server list:", error));
+    }
+  },
+  { urls: [V2RAY_API_URL] } // This filter ensures our listener only runs for this specific URL.
+);
+
+// Optional: Open the popup when the notification is clicked.
+chrome.notifications.onClicked.addListener(() => {
+    // This API to open the popup programmatically is not available in all browsers.
+    // It works in Chrome.
+    if (chrome.action.openPopup) {
+        chrome.action.openPopup();
+    }
+});
+
+
+// ^-- END OF ADDED CODE --^
+
 export {}


### PR DESCRIPTION
This commit introduces a network listener in the background script. It monitors requests to 'http://188.166.142.39/servers/list'. When a successful request is detected, it re-fetches the server list, stores it in local storage, and notifies the user.