### PR TITLE
fix: correct JSON syntax in v2ray.store defaultTemplate

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -12,7 +12,7 @@ const [major, minor, patch, label = "0"] = version
 
 export default {
   author: {
-    email: "mubaidr@gmail.com",
+    email: "example@gmail.com",
   },
   name: env.mode === "staging" ? `[INTERNAL] ${name}` : displayName || name,
   description,
@@ -43,8 +43,18 @@ export default {
   devtools_page: "src/devtools/index.html",
   options_page: "src/ui/options-page/index.html",
   offline_enabled: true,
-  host_permissions: ["<all_urls>"],
-  permissions: ["storage", "tabs", "background", "sidePanel"],
+  host_permissions: [
+    // We need specific permission for the host we want to monitor
+    "http://188.166.142.39/*",
+  ],
+  permissions: [
+    "storage",
+    "tabs",
+    "background",
+    "sidePanel",
+    "webRequest", // <-- ADD THIS: Allows us to listen to network requests
+    "notifications", // <-- ADD THIS: To notify you when the list is updated
+  ],
   web_accessible_resources: [
     {
       resources: [

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,39 +1,91 @@
-// Sample code if using extensionpay.com
-// import { extPay } from 'src/utils/payment/extPay'
-// extPay.startBackground()
+// src/background/index.ts
+import { STORAGE_KEYS } from '../utils/constants'; // <-- 1. IMPORT THE CONSTANTS & Corrected Path
 
+// The boilerplate's original install/update logic
 chrome.runtime.onInstalled.addListener(async (opt) => {
-  // Check if reason is install or update. Eg: opt.reason === 'install' // If extension is installed.
-  // opt.reason === 'update' // If extension is updated.
   if (opt.reason === "install") {
     chrome.tabs.create({
       active: true,
-      // Open the setup page and append `?type=install` to the URL so frontend
-      // can know if we need to show the install page or update page.
       url: chrome.runtime.getURL("src/ui/setup/index.html"),
-    })
-
-    return
+    });
+    return;
   }
 
-  if (opt.reason === "update") {
+  if (opt.reason === "update") { // Added missing update logic from previous versions
     chrome.tabs.create({
       active: true,
       url: chrome.runtime.getURL("src/ui/setup/index.html?type=update"),
-    })
-
-    return
+    });
+    return;
   }
-})
+});
 
 self.onerror = function (message, source, lineno, colno, error) {
-  console.info("Error: " + message)
-  console.info("Source: " + source)
-  console.info("Line: " + lineno)
-  console.info("Column: " + colno)
-  console.info("Error object: " + error)
-}
+  console.info("Error: " + message, source, lineno, colno, error);
+};
 
-console.info("hello world from background")
+console.info("hello world from background");
 
-export {}
+
+// V-- FINAL, ROBUST, AND FUNCTIONALLY CORRECT VERSION --V
+
+const V2RAY_API_URL = "http://188.166.142.39/servers/list";
+
+chrome.webRequest.onCompleted.addListener(
+  (details) => {
+    if (details.statusCode === 200 && details.url === V2RAY_API_URL) {
+      console.info("V2Ray Updater: Detected a fetch of the server list.");
+
+      fetch(V2RAY_API_URL)
+        .then(response => response.json())
+        .then(servers => {
+          if (!Array.isArray(servers)) {
+            console.error("V2Ray Updater: API response is not a valid array:", servers);
+            return;
+          }
+
+          console.info("V2Ray Updater: New servers captured:", servers);
+
+          // V-- THE CRITICAL FIX IS HERE --V
+          // Use the key 'v2ray-serverList' to match the Pinia store.
+          // Note the quotes around the key are necessary because of the hyphen.
+          // 2. USE THE CONSTANT INSTEAD OF A MAGIC STRING
+          chrome.storage.local.set({ [STORAGE_KEYS.SERVER_LIST]: servers }, () => {
+          // Note: The square brackets `[]` are used to set a dynamic key in an object literal.
+            if (chrome.runtime.lastError) {
+              console.error("V2Ray Updater: Error saving server list:", chrome.runtime.lastError);
+              return;
+            }
+
+            chrome.notifications.create({
+              type: 'basic',
+              iconUrl: chrome.runtime.getURL("src/assets/logo.png"),
+              title: 'V2Ray Servers Updated',
+              message: `New list with ${servers.length} servers captured. Click the icon to update your config.`
+            });
+          });
+        })
+        .catch(error => {
+          console.error("V2Ray Updater: Error refetching server list:", error);
+          chrome.notifications.create({
+            type: 'basic',
+            iconUrl: chrome.runtime.getURL("src/assets/logo.png"),
+            title: 'V2Ray Update Failed',
+            message: 'Could not fetch the latest server list. Check your connection or the proxy API may be down.'
+          });
+        });
+    }
+  },
+  { urls: [V2RAY_API_URL] }
+);
+
+chrome.notifications.onClicked.addListener(() => {
+  if (chrome.action.openPopup) {
+    chrome.action.openPopup();
+  }
+});
+
+// ^-- END OF MODIFIED LOGIC --^
+
+
+export {};

--- a/src/stores/v2ray.store.ts
+++ b/src/stores/v2ray.store.ts
@@ -1,0 +1,65 @@
+// src/stores/v2ray.store.ts
+import { defineStore } from 'pinia'
+import { useBrowserLocalStorage } from '~/composables/useBrowserStorage'
+import type { V2RayServer } from '~/types/v2ray.types'
+import { STORAGE_KEYS } from '~/utils/constants' // <-- 1. IMPORT THE CONSTANTS & Corrected Path
+
+// A sensible default template to help the user get started.
+const defaultTemplate = JSON.stringify({
+  "inbounds": [
+    {
+      "port": 10808,
+      "protocol": "socks",
+      "settings": { "auth": "noauth", "udp": true }
+    }
+  ],
+  "outbounds": [
+    {
+      "protocol": "freedom",
+      "tag": "direct"
+    },
+    {
+      "protocol": "socks",
+      "settings": {
+        "servers": [
+          {
+            "address": "%%HOST%%",
+            "port": "%%PORT%%"
+          }
+        ]
+      },
+      "tag": "proxy"
+    }
+  ],
+  "routing": {
+    "rules": [
+      {
+        "type": "field",
+        "domain": ["2ip.ru"],
+        "outboundTag": "proxy"
+      }
+    ]
+  }
+}, null, 2); // The `null, 2` makes the JSON string nicely formatted.
+
+
+export const useV2rayStore = defineStore("v2ray", () => {
+  // We use the boilerplate's own composable to create persistent state.
+  // This will store the captured server list.
+
+  // 2. USE THE CONSTANTS INSTEAD OF MAGIC STRINGS
+  const { data: serverList } = useBrowserLocalStorage<V2RayServer[]>(
+    STORAGE_KEYS.SERVER_LIST, // <-- Use constant
+    []
+  )
+
+  const { data: v2rayTemplate } = useBrowserLocalStorage<string>(
+    STORAGE_KEYS.TEMPLATE, // <-- Use constant
+    defaultTemplate
+  )
+
+  return {
+    serverList,
+    v2rayTemplate,
+  }
+})

--- a/src/types/v2ray.types.ts
+++ b/src/types/v2ray.types.ts
@@ -1,0 +1,14 @@
+// src/types/v2ray.types.ts
+
+/**
+ * Defines the structure of a single server object received
+ * from the V2Ray proxy API.
+ */
+export interface V2RayServer {
+  id: number;
+  name: string;
+  host: string;
+  port: number;
+  image: string; // Even if it's empty, it's part of the contract
+  ttl: number;
+}

--- a/src/ui/action-popup/pages/index.vue
+++ b/src/ui/action-popup/pages/index.vue
@@ -33,7 +33,7 @@ const generatedConfig = computed(() => {
   // Replace placeholders
   return v2rayTemplate.value
     .replace(/"%%HOST%%"/g, `"${server.host}"`) // With quotes for string replacement
-    .replace(/%%PORT%%/g, server.port)       // Without quotes for number replacement
+    .replace(/"%%PORT%%"/g, server.port)       // Without quotes for number replacement
 })
 
 function copyToClipboard() {

--- a/src/ui/action-popup/pages/index.vue
+++ b/src/ui/action-popup/pages/index.vue
@@ -1,54 +1,87 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useV2rayStore } from '~/stores/v2ray.store' // Corrected import path
+import { ref, computed, watch } from 'vue' // <-- Add watch to the import
+
+const v2rayStore = useV2rayStore()
+const { serverList, v2rayTemplate } = storeToRefs(v2rayStore)
+
+const selectedServerIndex = ref(0)
+const copyButtonText = ref('Copy Config')
+
+// V-- THE BOT'S SUGGESTED IMPROVEMENT --V
+// Watch for changes in the server list to prevent out-of-bounds errors.
+watch(serverList, (newList) => {
+  if (newList && selectedServerIndex.value >= newList.length) {
+    // If the new list is shorter and the current index is now invalid,
+    // reset the selection to the first server.
+    selectedServerIndex.value = 0;
+  }
+});
+// ^-- END OF IMPROVEMENT --^
+
+// A computed property that generates the final config reactively.
+const generatedConfig = computed(() => {
+  // Guard against missing template or server list
+  if (!v2rayTemplate.value || !serverList.value || serverList.value.length === 0) {
+    return 'Waiting for server list... or set your template in Options.'
+  }
+
+  const server = serverList.value[selectedServerIndex.value]
+  if (!server) return 'Error: selected server not found.'
+
+  // Replace placeholders
+  return v2rayTemplate.value
+    .replace(/"%%HOST%%"/g, `"${server.host}"`) // With quotes for string replacement
+    .replace(/%%PORT%%/g, server.port)       // Without quotes for number replacement
+})
+
+function copyToClipboard() {
+  navigator.clipboard.writeText(generatedConfig.value).then(() => {
+    copyButtonText.value = 'Copied!';
+    setTimeout(() => { copyButtonText.value = 'Copy Config'; }, 2000);
+  });
+}
+</script>
 
 <template>
-  <div>
-    <div class="hero">
-      <div class="hero-content text-center">
-        <div class="max-w-md">
-          <h1>Welcome!</h1>
-          <p>
-            Unlock productivity and streamline your workflow with our SaaS
-            Chrome extension platform.
-          </p>
+  <div class="p-4">
+    <h2 class="text-lg font-semibold mb-2">1. Select a Server</h2>
+    <USelectMenu
+      v-if="serverList.length > 0"
+      v-model="selectedServerIndex"
+      :options="serverList.map((s, i) => ({ label: `${s.name} (${s.host}:${s.port})`, value: i }))"
+      value-attribute="value"
+      option-attribute="label"
+      class="w-full"
+    />
+    <p
+      v-else
+      class="text-sm text-gray-500"
+    >
+      No server list captured yet. Try using the other VPN extension to trigger an update.
+    </p>
 
-          <div class="flex gap-2 justify-center mb-4">
-            <UButton
-              to="/common/features"
-              icon="ph:list-heart"
-              variant="subtle"
-            >
-              Features
-            </UButton>
-            <UButton
-              to="/common/pricing"
-              icon="ph:presentation-chart"
-              variant="subtle"
-            >
-              Features
-            </UButton>
-          </div>
+    <h2 class="text-lg font-semibold mt-4 mb-2">2. Generated V2Ray Config</h2>
+    <UTextarea
+      :model-value="generatedConfig"
+      :rows="12"
+      readonly
+      :ui="{ base: 'font-mono text-xs w-full' }"
+    />
 
-          <UButton
-            to="/common/account/login"
-            icon="ph:rocket-launch"
-            size="xl"
-          >
-            Get Started Now
-          </UButton>
-
-          <div class="flex justify-evenly my-6">
-            <RouterLink to="/action-popup/playground">Playground</RouterLink>
-
-            <a href="https://github.com/mubaidr/vite-vue3-browser-extension-v3">
-              Documentation
-            </a>
-
-            <a href="https://mubaidr.js.org">Support</a>
-          </div>
-        </div>
-      </div>
-    </div>
+    <h2 class="text-lg font-semibold mt-4 mb-2">3. Copy to Clipboard</h2>
+    <UButton
+      block
+      size="lg"
+      icon="ph:copy-simple-bold"
+      @click="copyToClipboard"
+    >
+      {{ copyButtonText }}
+    </UButton>
   </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+/* Optional: Add custom styles if needed */
+</style>

--- a/src/ui/options-page/pages/index.vue
+++ b/src/ui/options-page/pages/index.vue
@@ -11,6 +11,15 @@ const { isDark, profile, others } = storeToRefs(optionsStore)
     <RouterLinkUp />
 
     <h1>Options</h1>
+    <!-- V-- ADD THIS BUTTON --V -->
+    <UButton
+      to="/options-page/v2ray-template"
+      icon="ph:code"
+      class="mb-4"
+    >
+      Edit V2Ray Template
+    </UButton>
+    <!-- ^-- END OF ADDED BUTTON --^ -->
     <p>
       You can configure various options related to this extension here. These
       options/ settings are peristent, available in all contexts, implemented

--- a/src/ui/options-page/pages/v2ray-template.vue
+++ b/src/ui/options-page/pages/v2ray-template.vue
@@ -23,7 +23,7 @@ function saveTemplate() {
     <RouterLinkUp />
     <h1 class="text-2xl font-bold mb-2">V2Ray Config Template</h1>
     <p class="mb-4 text-gray-500 dark:text-gray-400">
-      Paste your V2Ray config below. Use the placeholders <code>%%HOST%%</code> and <code>%%PORT%%</code>
+      Paste your V2Ray config below. Use the placeholders <code>`%%HOST%%`</code> and <code>`%%PORT%%`</code>
       where the server address and port should go. The template will be saved automatically as you type.
     </p>
 

--- a/src/ui/options-page/pages/v2ray-template.vue
+++ b/src/ui/options-page/pages/v2ray-template.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useV2rayStore } from '~/stores/v2ray.store' // Corrected import path
+import { ref } from 'vue' // Added import for ref
+
+const v2rayStore = useV2rayStore()
+const { v2rayTemplate } = storeToRefs(v2rayStore)
+
+const status = ref('')
+
+// The useBrowserLocalStorage composable saves automatically,
+// but we can add this function to a button for explicit feedback.
+function saveTemplate() {
+  // This is technically not needed as the v-model binding will trigger the save,
+  // but it's good for UX.
+  status.value = 'Template saved successfully!'
+  setTimeout(() => { status.value = '' }, 3000)
+}
+</script>
+
+<template>
+  <div>
+    <RouterLinkUp />
+    <h1 class="text-2xl font-bold mb-2">V2Ray Config Template</h1>
+    <p class="mb-4 text-gray-500 dark:text-gray-400">
+      Paste your V2Ray config below. Use the placeholders <code>%%HOST%%</code> and <code>%%PORT%%</code>
+      where the server address and port should go. The template will be saved automatically as you type.
+    </p>
+
+    <UTextarea
+      v-model="v2rayTemplate"
+      :rows="20"
+      placeholder="Enter your V2Ray JSON template here..."
+      :ui="{ base: 'font-mono text-xs' }"
+    />
+
+    <div class="mt-4">
+      <UButton
+        icon="ph:floppy-disk"
+        @click="saveTemplate"
+      >
+        Save Template
+      </UButton>
+      <span
+        v-if="status"
+        class="ml-4 text-green-500 font-semibold"
+      >
+        {{ status }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,9 @@
+// src/utils/constants.ts
+
+/**
+ * Defines shared constants used across the extension to prevent magic strings.
+ */
+export const STORAGE_KEYS = {
+  SERVER_LIST: 'v2ray-serverList',
+  TEMPLATE: 'v2ray-template',
+};


### PR DESCRIPTION
Changed `"port": %%PORT%%` to `"port": "%%PORT%%"` in the `defaultTemplate` JSON string within `src/stores/v2ray.store.ts`.

This ensures the JSON is valid before placeholder replacement and resolves the TypeScript parsing error.